### PR TITLE
Made caniusepython3 as script. Fix #2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ of them are holding you up from porting to Python 3.
 
 You can specify your dependencies in multiple ways::
 
-    python3 -m caniusepython3 -r requirements.txt
-    python3 -m caniusepython3 -m PKG-INFO
-    python3 -m caniusepython3 -p numpy,scipy,ipython
+    caniusepython3 -r requirements.txt
+    caniusepython3 -m PKG-INFO
+    caniusepython3 -p numpy,scipy,ipython
 
 The output of the script will list which projects are directly holding up some
 (implicit) dependency from working on Python 3.

--- a/caniusepython3.py
+++ b/caniusepython3.py
@@ -184,7 +184,7 @@ def projects_from_cli(args):
     return projects
 
 
-if __name__ == '__main__':
+def main():
     projects = projects_from_cli(sys.argv[1:])
     logging.info('{} top-level projects to check'.format(len(projects)))
     print('Finding and checking dependencies ...')
@@ -198,3 +198,7 @@ if __name__ == '__main__':
     print('{} dependencies have no other dependencies blocking a port to Python 3:'.format(len(blocking)))
     for blocker in sorted(blocking, key=lambda x: tuple(reversed(x))):
         print(' <- '.join(blocker))
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 with open('README.md') as file:
     # Try my best to have at least the intro in Markdown/reST.
@@ -16,7 +16,7 @@ setup(name='caniusepython3',
       author_email='brett@python.org',
       url='https://github.com/brettcannon/caniusepython3',
       py_modules=['caniusepython3'],
-      requires=requires,
+      install_requires=requires,
       classifiers=[
           'Development Status :: 4 - Beta',
           'Environment :: Console',
@@ -24,4 +24,9 @@ setup(name='caniusepython3',
           'License :: OSI Approved :: Apache Software License',
           'Programming Language :: Python :: 3',
       ],
+      entry_points={
+          'console_scripts': [
+              'caniusepython3=caniusepython3:main',
+          ]
+      },
 )


### PR DESCRIPTION
This uses setuptools since it's the best option for making this work cross
platform. This also actually tells pip/easy_install/etc to install the
dependencies.
