### PR TITLE
Allow multiple requirements files to be specified.

### DIFF
--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -26,23 +26,24 @@ import logging
 import sys
 
 
-def projects_from_requirements(requirements_path):
+def projects_from_requirements(requirements):
     """Extract the project dependencies from a Requirements specification."""
     log = logging.getLogger('ciu')
-    reqs = pip.req.parse_requirements(requirements_path)
     valid_reqs = []
-    for req in reqs:
-        if not req.name:
-            log.warning('A requirement lacks a name '
-                        '(e.g. no `#egg` on a `file:` path)')
-        elif req.editable:
-            log.warning(
-                'Skipping {0}: editable projects unsupported'.format(req.name))
-        elif req.url and req.url.startswith('file:'):
-            log.warning(
-                'Skipping {0}: file-specified projects unsupported'.format(req.name))
-        else:
-            valid_reqs.append(req.name)
+    for requirements_path in requirements:
+        reqs = pip.req.parse_requirements(requirements_path)
+        for req in reqs:
+            if not req.name:
+                log.warning('A requirement lacks a name '
+                            '(e.g. no `#egg` on a `file:` path)')
+            elif req.editable:
+                log.warning(
+                    'Skipping {0}: editable projects unsupported'.format(req.name))
+            elif req.url and req.url.startswith('file:'):
+                log.warning(
+                    'Skipping {0}: file-specified projects unsupported'.format(req.name))
+            else:
+                valid_reqs.append(req.name)
     return valid_reqs
 
 
@@ -59,6 +60,7 @@ def projects_from_cli(args):
     parser = argparse.ArgumentParser(description=description)
     req_help = ('path to a pip requirements file (e.g. requirements.txt)')
     parser.add_argument('--requirements', '-r', nargs='?',
+                        type=lambda arg: arg.split(','),
                         help=req_help)
     meta_help = 'path to a PEP 426 metadata file (e.g. PKG-INFO, pydist.json)'
     parser.add_argument('--metadata', '-m', nargs='?',

--- a/caniusepython3/test/test_cli.py
+++ b/caniusepython3/test/test_cli.py
@@ -72,8 +72,21 @@ class CLITests(unittest.TestCase):
         with tempfile.NamedTemporaryFile('w') as file:
             file.write(EXAMPLE_REQUIREMENTS)
             file.flush()
-            got = ciu_main.projects_from_requirements(file.name)
+            got = ciu_main.projects_from_requirements([file.name])
         self.assertEqual(set(got), self.expected_requirements)
+
+    def test_multiple_requirements_files(self):
+        with tempfile.NamedTemporaryFile('w') as f1:
+            with tempfile.NamedTemporaryFile('w') as f2:
+                f1.write(EXAMPLE_REQUIREMENTS)
+                f1.flush()
+                f2.write('foobar')
+                f2.flush()
+                got = ciu_main.projects_from_requirements([f1.name, f2.name])
+        expected_requirements = frozenset(
+            list(self.expected_requirements) + ['foobar']
+        )
+        self.assertEqual(set(got), expected_requirements)
 
     def test_metadata(self):
         got = ciu_main.projects_from_metadata(EXAMPLE_METADATA)


### PR DESCRIPTION
Some projects have more than one requirements file: this is the case for
OpenStack projects, which usually have requirements.txt, test-requirements.txt
and sometimes Python3 specific requirements.

This patch allows users to specify multiple requirements file by using this
syntax:

```
caniusepython3 -r req1.txt,req2.txt,req3.txt
```

The behaviour is unchanged if a single file is used.
