### PR TITLE
override uwsgi

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -19,6 +19,7 @@
     "ssl": "http://docs.python.org/3/library/ssl.html",
     "unittest2": "http://docs.python.org/3/library/unittest.html",
     "uuid": "http://docs.python.org/3/library/uuid.html",
+    "uwsgi": "https://pypi.python.org/pypi/uWSGI",
     "wsgiref": "http://docs.python.org/3/library/wsgiref.html",
     "xlwt": "https://pypi.python.org/pypi/xlwt-future",
     "zc.recipe.egg": "https://pypi.python.org/pypi/zc.recipe.egg/"


### PR DESCRIPTION
As reported here https://github.com/chhantyal/py3readiness/issues/1 `uwsgi` supports Python 3 but maintains very minimal `setup.py`. 

Python 3 support verified here https://uwsgi-docs.readthedocs.org/en/latest/LanguagesAndPlatforms.html 
