### PR TITLE
Call the existing test suite directly in setup.py test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='caniusepython3',
       install_requires=['distlib', 'setuptools', 'pip',  # Input flexibility
                         'argparse', 'futures',  # Functionality
                         'mock'],  # Testing
+      test_suite='caniusepython3.test',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',


### PR DESCRIPTION
As requested in #32, this calls the tests directly without using nose.
