### PR TITLE
Add overrides for extras and warlock.

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -1,7 +1,6 @@
 {
     "beautifulsoup": "https://pypi.python.org/pypi/beautifulsoup4",
     "django-social-auth": "https://pypi.python.org/pypi/python-social-auth",
-    "envoy": "https://github.com/kennethreitz/envoy/blob/master/setup.py",
     "extras": "https://pypi.python.org/pypi/extras",
     "httpretty": "https://twitter.com/CyrilRoelandt/status/437995014321238016",
     "ipaddress": "http://docs.python.org/3/library/ipaddress.html",
@@ -21,7 +20,7 @@
     "unittest2": "http://docs.python.org/3/library/unittest.html",
     "uuid": "http://docs.python.org/3/library/uuid.html",
     "uwsgi": "https://pypi.python.org/pypi/uWSGI",
-    "warlock": "https://github.com/bcwaldon/warlock/pull/9",
+    "warlock": "https://github.com/bcwaldon/warlock/blob/master/tox.ini",
     "wsgiref": "http://docs.python.org/3/library/wsgiref.html",
     "xlwt": "https://pypi.python.org/pypi/xlwt-future",
     "zc.recipe.egg": "https://pypi.python.org/pypi/zc.recipe.egg/"


### PR DESCRIPTION
These three projects have Python 3 support and don't seem interested in updating their trove classifiers. Botocore, aws-cli, bcdoc, and jmespath also support Python 3 now and I can add those as well if you think that is a good idea before boto itself supports Python 3.
