### PR TITLE
Add botocore-related package overrides.

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -1,9 +1,13 @@
 {
+    "awscli":"https://pypi.python.org/pypi/awscli",
     "beautifulsoup": "https://pypi.python.org/pypi/beautifulsoup4",
+    "bcdoc":"https://github.com/boto/bcdoc/blob/master/tox.ini",
+    "botocore":"https://github.com/boto/botocore/blob/master/tox.ini",
     "django-social-auth": "https://pypi.python.org/pypi/python-social-auth",
     "extras": "https://pypi.python.org/pypi/extras",
     "httpretty": "https://twitter.com/CyrilRoelandt/status/437995014321238016",
     "ipaddress": "http://docs.python.org/3/library/ipaddress.html",
+    "jmespath": "https://github.com/boto/jmespath/blob/master/tox.ini",
     "mox": "https://pypi.python.org/pypi/mox3",
     "mox3": "https://pypi.python.org/pypi/mox3",
     "multiprocessing": "http://docs.python.org/3/library/multiprocessing.html",


### PR DESCRIPTION
Their trove classifiers don't seem to be showing up on PyPI.
