### PR TITLE
add ssh lib override

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -20,7 +20,7 @@
     "python-memcached": "https://pypi.python.org/pypi/python3-memcached",
     "pyvirtualdisplay": "https://pypi.python.org/pypi/PyVirtualDisplay",
     "rsa": "https://pypi.python.org/pypi/rsa",
-    "ssh": "https://pypi.python.org/pypi/paramiko",
+    "ssh": "https://github.com/bitprophet/ssh/",
     "ssl": "http://docs.python.org/3/library/ssl.html",
     "unittest2": "http://docs.python.org/3/library/unittest.html",
     "uuid": "http://docs.python.org/3/library/uuid.html",


### PR DESCRIPTION
`ssh` lib is merged back to `paramiko` and later is active in development. 

Detailed blog post here http://bitprophet.org/blog/2012/09/29/paramiko-and-ssh/
