### PR TITLE
Add overrides for regex and pystache.

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -17,6 +17,7 @@
     "pil": "https://pypi.python.org/pypi/Pillow",
     "pyrss2gen": "https://pypi.python.org/pypi/PyRSS2Gen",
     "pysqlite": "http://docs.python.org/3/library/sqlite3.html",
+    "pystache": "https://pypi.python.org/pypi/pystache",
     "python-memcached": "https://pypi.python.org/pypi/python3-memcached",
     "pyvirtualdisplay": "https://pypi.python.org/pypi/PyVirtualDisplay",
     "regex": "https://pypi.python.org/pypi/regex",


### PR DESCRIPTION
Trove classifier includes Python 3 versions and the PyPI page makes references to various behaviour that is different in Python 3. I wasn't sure how to link to a release version of `setup.py` on Google Code but I installed this using pip and it worked without issues.
