### PR TITLE
Override py-bcrypt and pycountry

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -17,6 +17,8 @@
     "multiprocessing": "http://docs.python.org/3/library/multiprocessing.html",
     "ordereddict": "http://docs.python.org/3/library/collections.html#collections.OrderedDict",
     "pil": "https://pypi.python.org/pypi/Pillow",
+    "py-bcrypt": "https://code.google.com/p/py-bcrypt/",
+    "pycountry": "https://pypi.python.org/pypi/pycountry",
     "pyephem": "https://pypi.python.org/pypi/ephem/",
     "pypdf": "https://pypi.python.org/pypi/PyPDF2",
     "pyrss2gen": "https://pypi.python.org/pypi/PyRSS2Gen",


### PR DESCRIPTION
`pycountry` added support in June 2013 and `py-bcrypt` in August 2013.
