### PR TITLE
Added pytz to overrides

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -23,6 +23,7 @@
     "pysqlite": "http://docs.python.org/3/library/sqlite3.html",
     "python-memcached": "https://pypi.python.org/pypi/python3-memcached",
     "python-neutronclient": "https://pypi.python.org/pypi/python-neutronclient",
+    "pytz": "https://pypi.python.org/pypi/pytz",
     "pyvirtualdisplay": "https://pypi.python.org/pypi/PyVirtualDisplay",
     "regex": "https://pypi.python.org/pypi/regex",
     "rsa": "https://pypi.python.org/pypi/rsa",


### PR DESCRIPTION
This change adds the package `pytz` to the `overrides.json` file as it supports Python 3.

Proof: the page on PyPI includes releases for Python 3.1, 3.2, 3.3 and 3.4 plus a universal wheel file: https://pypi.python.org/pypi/pytz.
