### PR TITLE
override djangocms-admin-style

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -4,6 +4,7 @@
     "bcdoc":"https://github.com/boto/bcdoc/blob/master/tox.ini",
     "botocore":"https://github.com/boto/botocore/blob/master/tox.ini",
     "collective.recipe.template": "https://pypi.python.org/pypi/collective.recipe.template",
+    "djangocms-admin-style":"https://github.com/divio/djangocms-admin-style",
     "django-social-auth": "https://pypi.python.org/pypi/python-social-auth",
     "dnspython": "https://pypi.python.org/pypi/dnspython3",
     "extras": "https://pypi.python.org/pypi/extras",


### PR DESCRIPTION
Eg. this package doesn't have python code https://github.com/divio/djangocms-admin-style

I think we should just flag these kinda packages.
