### PR TITLE
Override requests-oauthlib.

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -26,6 +26,7 @@
     "pyvirtualdisplay": "https://pypi.python.org/pypi/PyVirtualDisplay",
     "regex": "https://pypi.python.org/pypi/regex",
     "reportlab": "https://pypi.python.org/pypi/reportlab",
+    "requests-oauthlib": "https://pypi.python.org/pypi/requests-oauthlib",
     "rsa": "https://pypi.python.org/pypi/rsa",
     "ssh": "https://github.com/bitprophet/ssh/",
     "ssl": "http://docs.python.org/3/library/ssl.html",


### PR DESCRIPTION
Stopgap measure until they update their trove classifiers again.