### PR TITLE
Don't barf if requirement has no `url` attribute

### DIFF
--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -43,12 +43,22 @@ def projects_from_requirements(requirements):
             elif req.editable:
                 log.warning(
                     'Skipping {0}: editable projects unsupported'.format(req.name))
-            elif req.url and req.url.startswith('file:'):
+            elif req_has_file_link(req):
                 log.warning(
                     'Skipping {0}: file-specified projects unsupported'.format(req.name))
             else:
                 valid_reqs.append(req.name)
     return valid_reqs
+
+
+def req_has_file_link(req):
+    url = getattr(req, 'url', None)
+    if url and url.lower().startswith('file:'):
+        return True
+    link = getattr(req, 'link', None)
+    if link and getattr(link, 'scheme', '') == 'file':
+        return True
+    return False
 
 
 def projects_from_metadata(metadata):


### PR DESCRIPTION
Without this, I was getting (with pip 6.1.0.dev0):

    [marca@marca-mac2 profilesvc]$ cat reqs2.txt
    ipython
    pygments
    pyramid

    [marca@marca-mac2 profilesvc]$ caniusepython3 --requirements reqs2.txt
    Traceback (most recent call last):
      File "/Library/Frameworks/Python.framework/Versions/2.7/bin/caniusepython3", line 9, in <module>
        load_entry_point('caniusepython3==3.0.0', 'console_scripts', 'caniusepython3')()
      File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/caniusepython3/__main__.py", line 159, in main
        check(projects_from_cli(args))
      File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/caniusepython3/__main__.py", line 86, in projects_from_cli
        projects.extend(projects_from_requirements(parsed.requirements))
      File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/caniusepython3/__main__.py", line 46, in projects_from_requirements
        elif req.url and req.url.startswith('file:'):
    AttributeError: 'InstallRequirement' object has no attribute 'url'

I believe this is because `pip` changed the name of the attribute from `url` to `link` (see https://github.com/pypa/pip/pull/2280).

Cc: @xavfernandez