### PR TITLE
Display "0 projects blocking..." message w/ flair

### DIFF
--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -28,6 +28,12 @@ import io
 import logging
 import sys
 
+try:
+    from colorama import Fore, Back, Style
+    color_enabled = True
+except ImportError:
+    color_enabled = False
+
 
 def projects_from_requirements(requirements):
     """Extract the project dependencies from a Requirements specification."""
@@ -97,7 +103,11 @@ def projects_from_cli(args):
 def message(blockers):
     """Create a sequence of key messages based on what is blocking."""
     if not blockers:
-        return ['You have 0 projects blocking you from using Python 3!']
+        msg = 'You have 0 projects blocking you from using Python 3!'
+        if color_enabled:
+            beer = u'\U0001f37a'
+            msg = beer + '  ' + Fore.GREEN + Style.BRIGHT + msg + Fore.RESET
+        return [msg]
     flattened_blockers = set()
     for blocker_reasons in blockers:
         for blocker in blocker_reasons:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='caniusepython3',
       include_package_data=True,
       install_requires=['distlib', 'setuptools', 'pip',  # Input flexibility
                         'argparse', 'futures'],  # Functionality
+      extras_require={'color': ['colorama']},
       tests_require=tests_require,  # Testing, external due to Travis
       test_suite='caniusepython3.test',
       classifiers=[


### PR DESCRIPTION
Add a little flair when projects are Python 3 compatible.

![screen shot 2015-03-13 at 12 16 25 am](https://cloud.githubusercontent.com/assets/305268/6634515/e031820a-c916-11e4-89c2-54a7569c52f4.png)

Because who couldn't use a bit more flair?

![imgres](https://cloud.githubusercontent.com/assets/305268/6634511/d1e8af3e-c916-11e4-8d97-5815f38a0afa.jpg)
