### PR TITLE
Add logging

### DIFF
--- a/caniusepython3/dependencies.py
+++ b/caniusepython3/dependencies.py
@@ -77,6 +77,7 @@ def blocking_dependencies(projects, py3_projects):
     check = []
     evaluated = set()
     for project in projects:
+        log.info('Checking top-level project: {0} ...'.format(project))
         dist = distlib.locators.locate(project)
         if not dist:
             log.warning('{0} not found'.format(project))
@@ -97,7 +98,9 @@ def blocking_dependencies(projects, py3_projects):
                     # can't port.
                     del reasons[parent]
                     continue
+                log.info('Dependencies of {0}: {1}'.format(project, deps))
                 for dep in deps:
+                    log.info('Checking dependency: {0} ...'.format(dep))
                     if dep in evaluated:
                         log.info('{0} already checked'.format(dep))
                         continue


### PR DESCRIPTION
to aid in understanding how caniusepython3 works under the hood.

E.g.:

```
$ caniusepython3 --projects diesel -v
[INFO] 1 top-level projects to check
Finding and checking dependencies ...
...
[INFO] Checking top-level project: diesel ...
[INFO] Locating diesel
[INFO] Dependencies of diesel: [u'http-parser', u'pyopenssl', u'twiggy', u'greenlet', u'flask', u'dnspython']
[INFO] Checking dependency: http-parser ...
[INFO] Checking dependency: pyopenssl ...
[INFO] Checking dependency: twiggy ...
[INFO] Checking dependency: greenlet ...
[INFO] Checking dependency: flask ...
[INFO] Checking dependency: dnspython ...

You need 1 project to transition to Python 3.
Of that 1 project, 1 has no direct dependencies blocking its transition:

  diesel
```
