### PR TITLE
xlwt now supports Python 3.3+

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -35,6 +35,5 @@
     "uwsgi": "https://pypi.python.org/pypi/uWSGI",
     "warlock": "https://github.com/bcwaldon/warlock/blob/master/tox.ini",
     "wsgiref": "http://docs.python.org/3/library/wsgiref.html",
-    "xlwt": "https://pypi.python.org/pypi/xlwt-future",
     "zc.recipe.egg": "https://pypi.python.org/pypi/zc.recipe.egg/"
 }


### PR DESCRIPTION
This override is no longer needed as xlwt supports Python 3.3+:

https://pypi.python.org/pypi/xlwt