### PR TITLE
Prevent MemoryError crash when a package specifies circular dependenies

### DIFF
--- a/caniusepython3/dependencies.py
+++ b/caniusepython3/dependencies.py
@@ -23,6 +23,10 @@ import concurrent.futures
 import logging
 
 
+class CircularDependencyError(Exception):
+    """Raised if there are ciruclar dependencies detected."""
+
+
 class LowerDict(dict):
 
     def __getitem__(self, key):
@@ -42,6 +46,10 @@ def reasons_to_paths(reasons):
         path = [blocker]
         parent = reasons[blocker]
         while parent:
+            if parent in path:
+                raise CircularDependencyError(dict(parent=parent,
+                                                   blocker=blocker,
+                                                   path=path))
             path.append(parent)
             parent = reasons.get(parent)
         paths.add(tuple(path))

--- a/caniusepython3/test/test_dependencies.py
+++ b/caniusepython3/test/test_dependencies.py
@@ -23,6 +23,16 @@ import io
 
 class GraphResolutionTests(unittest.TestCase):
 
+    def test_circular_dependencies(self):
+        reasons = {
+            'A': 'C',
+            'B': 'C',
+            'C': 'A',
+        }
+        self.assertRaises(dependencies.CircularDependencyError,
+                          dependencies.reasons_to_paths,
+                          reasons)
+
     def test_all_projects_okay(self):
         # A, B, and C are fine on their own.
         self.assertEqual(set(), dependencies.reasons_to_paths({}))


### PR DESCRIPTION
Fixes #89 

I'm not sure this is the desired behaviour (throwing an exception when circular dependencies are detected). It does prevent the MemoryError crash.
