### PR TITLE
Remove certifi

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -3,7 +3,6 @@
     "bcdoc": "https://github.com/boto/bcdoc/blob/master/tox.ini",
     "botocore": "https://github.com/boto/botocore/blob/master/tox.ini",
     "collective.recipe.template": "https://pypi.python.org/pypi/collective.recipe.template",
-    "certifi": "https://pypi.python.org/pypi/certifi",
     "djangocms-admin-style": "https://github.com/divio/djangocms-admin-style",
     "django-social-auth": "https://pypi.python.org/pypi/python-social-auth",
     "dnspython": "https://pypi.python.org/pypi/dnspython3",


### PR DESCRIPTION
Just spotted #96 and felt like it might be more expedient to fix up certifi, so I re-registered it to update the trove classifiers. If you check [certifi](https://pypi.python.org/pypi/certifi) you'll notice its classifiers are present (and support all Python 3 versions).

Thanks for spotting our error!