### PR TITLE
Add functools32 to overrides.

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -8,6 +8,7 @@
     "dnspython": "https://pypi.python.org/pypi/dnspython3",
     "extras": "https://pypi.python.org/pypi/extras",
     "flask-login": "https://github.com/maxcountryman/flask-login/blob/528e1efc69162b433825c4c02f62a1226eadc570/.travis.yml",
+    "functools32": "https://pypi.python.org/pypi/functools32",
     "futures": "https://docs.python.org/3/library/concurrent.futures.html",
     "httpretty": "https://twitter.com/CyrilRoelandt/status/437995014321238016",
     "ipaddress": "https://docs.python.org/3/library/ipaddress.html#module-ipaddress",


### PR DESCRIPTION
This is a backport of Python 3 functionality.