### PR TITLE
Update overrides.json

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -15,6 +15,7 @@
     "mox": "https://pypi.python.org/pypi/mox3",
     "mox3": "https://pypi.python.org/pypi/mox3",
     "multiprocessing": "http://docs.python.org/3/library/multiprocessing.html",
+    "ndg-httpsclient": "https://pypi.python.org/pypi/ndg-httpsclient",
     "ordereddict": "http://docs.python.org/3/library/collections.html#collections.OrderedDict",
     "pil": "https://pypi.python.org/pypi/Pillow",
     "py-bcrypt": "https://code.google.com/p/py-bcrypt/",


### PR DESCRIPTION
`ndg-httpsclient` lists Python 3 compatibility on PyPI.