### PR TITLE
prevent AttributeError for dict comprehensions

### DIFF
--- a/caniusepython3/pylint_checker.py
+++ b/caniusepython3/pylint_checker.py
@@ -52,7 +52,7 @@ class StrictPython3Checker(checkers.BaseChecker):
     _changed_builtins = frozenset(['open'])
 
     def visit_name(self, node):
-        if node.lookup(node.name)[0].name == '__builtin__':
+        if getattr(node.lookup(node.name)[0], 'name', '') == '__builtin__':
             if node.name in self._changed_builtins:
                 self.add_message(node.name + '-builtin', node=node)
 

--- a/caniusepython3/pylint_checker.py
+++ b/caniusepython3/pylint_checker.py
@@ -52,7 +52,7 @@ class StrictPython3Checker(checkers.BaseChecker):
     _changed_builtins = frozenset(['open'])
 
     def visit_name(self, node):
-        if getattr(node.lookup(node.name)[0], 'name', '') == '__builtin__':
+        if hasattr(node, 'name') and getattr(node.lookup(node.name)[0], 'name', '') == '__builtin__':
             if node.name in self._changed_builtins:
                 self.add_message(node.name + '-builtin', node=node)
 

--- a/caniusepython3/test/test_pylint_checker.py
+++ b/caniusepython3/test/test_pylint_checker.py
@@ -66,6 +66,10 @@ class StrictPython3CheckerTest(CheckerTestCase):
     def test_open_builtin(self):
         self.check_not_builtin('open', 'open-builtin')
 
+    def test_dict_comprehension(self):
+        node = test_utils.extract_node('{e:"1" for e in ["one", "two"]} #@')
+        with self.assertNoMessages():
+            self.checker.visit_name(node)
 
 @new_enough
 class UnicodeCheckerTest(CheckerTestCase):


### PR DESCRIPTION
In ran accross this attribute error for DictComp while running pylint_checker with py27.
