### PR TITLE
Update overrides.json

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -25,6 +25,7 @@
     "pil": "https://pypi.python.org/pypi/Pillow",
     "py-bcrypt": "https://code.google.com/p/py-bcrypt/",
     "pycountry": "https://pypi.python.org/pypi/pycountry",
+    "pyodbc": "https://code.google.com/p/pyodbc/",
     "pypdf": "https://pypi.python.org/pypi/PyPDF2",
     "pyrss2gen": "https://pypi.python.org/pypi/PyRSS2Gen",
     "pysqlite": "http://docs.python.org/3/library/sqlite3.html",

--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -25,7 +25,7 @@
     "pil": "https://pypi.python.org/pypi/Pillow",
     "py-bcrypt": "https://code.google.com/p/py-bcrypt/",
     "pycountry": "https://pypi.python.org/pypi/pycountry",
-    "pyodbc": "https://code.google.com/p/pyodbc/",
+    "pyodbc": "http://mkleehammer.github.io/pyodbc/releases.html",
     "pypdf": "https://pypi.python.org/pypi/PyPDF2",
     "pyrss2gen": "https://pypi.python.org/pypi/PyRSS2Gen",
     "pysqlite": "http://docs.python.org/3/library/sqlite3.html",


### PR DESCRIPTION
`pyodbc` has supported Python 3 for several releases as indicated at http://mkleehammer.github.io/pyodbc/releases.html.