### PR TITLE
override no longer needed for testresources

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -40,7 +40,6 @@
     "ssh": "https://github.com/bitprophet/ssh/",
     "ssl": "http://docs.python.org/3/library/ssl.html",
     "suds": "https://pypi.python.org/pypi/suds-jurko",
-    "testresources": "https://pypi.python.org/pypi/testresources",
     "trisdb-py": "https://github.com/tiepologian/trisdb-py/blob/master/setup.cfg",
     "unittest2": "http://docs.python.org/3/library/unittest.html",
     "uuid": "http://docs.python.org/3/library/uuid.html",


### PR DESCRIPTION
The trove classifiers are fixed for https://pypi.python.org/pypi/testresources so an override isn't needed.