### PR TITLE
Skip tests that trigger an xmlrpc.client.ProtocolError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-*env
+venv*
+.vscode
 
 *.py[cod]
 


### PR DESCRIPTION
Only skipped if it's a server-side PyPI cause (i.e. error code >= 500).