### PR TITLE
filechunkio no longer needed here

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -4,7 +4,6 @@
     "django-social-auth": "https://pypi.python.org/pypi/python-social-auth",
     "dnspython": "https://pypi.python.org/pypi/dnspython3",
     "fabric": "https://pypi.python.org/pypi/Fabric3",
-    "filechunkio": "https://bitbucket.org/fabian/filechunkio/commits/5a1d0b614e506e5198090a5201770e2524fa8720",
     "flask-debugtoolbar": "https://pypi.python.org/pypi/Flask-DebugToolbar",
     "flask-mail": "http://pythonhosted.org/Flask-Mail/changelog.html#version-0-9-0",
     "flask-security": "http://pythonhosted.org/Flask-Security/changelog.html#version-1-7-3",


### PR DESCRIPTION
https://pypi.python.org/pypi/filechunkio added a trove classifer for Python 3, so it isn't needed in this list anymore.