### PR TITLE
ipaddr has a forked version in Python 3

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -11,6 +11,7 @@
     "flask-principal": "http://pythonhosted.org/Flask-Principal/changelog.html",
     "functools32": "https://pypi.python.org/pypi/functools32",
     "hashids": "https://pypi.python.org/pypi/hashids",
+    "ipaddr": "https://docs.python.org/3/library/ipaddress.html",
     "jinja": "http://jinja.pocoo.org/docs/switching/#jinja1",
     "mox": "https://pypi.python.org/pypi/mox3",
     "multiprocessing": "http://docs.python.org/3/library/multiprocessing.html",


### PR DESCRIPTION
The `ipaddr` library was forked and became for the Python 3 builtin library `ipaddress`: https://docs.python.org/3/library/ipaddress.html

That's noted by AlexFinkel in this discussion: https://github.com/google/ipaddr-py/pull/118