### PR TITLE
Change URL away from what will be warehouse to legacy

### DIFF
--- a/caniusepython3/pypi.py
+++ b/caniusepython3/pypi.py
@@ -46,7 +46,7 @@ def just_name(supposed_name):
 
 @contextlib.contextmanager
 def pypi_client():
-    client = xmlrpc_client.ServerProxy('https://pypi.io/pypi')
+    client = xmlrpc_client.ServerProxy('https://pypi.org/pypi')
     try:
         yield client
     finally:


### PR DESCRIPTION
Addresses brettcannon/caniusepython3#150 by changing the URL away from pypi.io (which appears to be running warehouse) to pypi.org (similar to URL from [PyPI's XML-RPC methods documentation](https://warehouse.pypa.io/api-reference/xml-rpc/)).