### PR TITLE
Move over to PyPI's JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ and [extension modules](http://docs.python.org/3/howto/cporting.html).
 
 # Change Log
 
+# 3.4.1
+* Update the URL used for PyPI to https://pypi.org
+  (patch by [Chris Fournier](https://github.com/cfournie))
+* Usual override updates
+
 # 3.4.0
 * Fix a dict comprehension failure with the pylint checker
   (patch by [Jeroen Oldenburger](https://github.com/jeroenoldenburger))

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ and [extension modules](http://docs.python.org/3/howto/cporting.html).
 
 # Change Log
 
+# 4.0.0 [under development]
+* Stop using PyPI's XML-RPC API and move to its JSON one for better performance
+* Load the overrides data from GitHub when possible, falling back to the data
+  included with the package when necessary
+
 # 3.4.1
 * Update the URL used for PyPI to https://pypi.org
   (patch by [Chris Fournier](https://github.com/cfournie))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,7 @@
 0. Make sure all changes are live and that Travis is green
 0. Verify there are no stale overrides
 0. Update README.md with release notes
+0. Delete `dist/*`
 0. Update setup.py for the new version number
 0. `python3 -m pip install --upgrade setuptools twine wheel`
 0. `python3 setup.py sdist`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,5 @@
 0. Make sure all changes are live and that Travis is green
+0. Verify there are no stale overrides
 0. Update README.md with release notes
 0. Update setup.py for the new version number
 0. `python3 -m pip install --upgrade setuptools twine wheel`

--- a/caniusepython3/__init__.py
+++ b/caniusepython3/__init__.py
@@ -38,10 +38,10 @@ def check(requirements_paths=[], metadata=[], projects=[]):
 
     Any project that is not listed on PyPI will be considered ported.
     """
-    dependencies = main.projects_from_requirements(requirements_paths)
+    dependencies = []
+    dependencies.extend(main.projects_from_requirements(requirements_paths))
     dependencies.extend(main.projects_from_metadata(metadata))
     dependencies.extend(projects)
-    dependencies = set(name.lower() for name in dependencies)
 
     py3_projects = pypi.all_py3_projects()
     all_projects = pypi.all_projects()

--- a/caniusepython3/__init__.py
+++ b/caniusepython3/__init__.py
@@ -43,10 +43,11 @@ def check(requirements_paths=[], metadata=[], projects=[]):
     dependencies.extend(main.projects_from_metadata(metadata))
     dependencies.extend(projects)
 
-    py3_projects = pypi.all_py3_projects()
-    all_projects = pypi.all_projects()
+    manual_overrides = pypi.manual_overrides()
 
     for dependency in dependencies:
-        if dependency in all_projects and dependency not in py3_projects:
+        if dependency in manual_overrides:
+            continue
+        elif not pypi.supports_py3(dependency):
             return False
     return True

--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -20,6 +20,7 @@ from caniusepython3 import pypi
 from caniusepython3 import dependencies
 
 import distlib.metadata
+import packaging.utils
 import pip.download
 import pip.req
 
@@ -48,7 +49,7 @@ def projects_from_requirements(requirements):
                     'Skipping {0}: file-specified projects unsupported'.format(req.name))
             else:
                 valid_reqs.append(req.name)
-    return valid_reqs
+    return frozenset(map(packaging.utils.canonicalize_name, valid_reqs))
 
 
 def req_has_file_link(req):
@@ -67,7 +68,7 @@ def projects_from_metadata(metadata):
     for data in metadata:
         meta = distlib.metadata.Metadata(fileobj=io.StringIO(data))
         projects.extend(pypi.just_name(project) for project in meta.run_requires)
-    return projects
+    return frozenset(map(packaging.utils.canonicalize_name, projects))
 
 
 def projects_from_cli(args):
@@ -99,7 +100,7 @@ def projects_from_cli(args):
         with io.open(metadata_path) as file:
             metadata.append(file.read())
     projects.extend(projects_from_metadata(metadata))
-    projects.extend(parsed.projects)
+    projects.extend(map(packaging.utils.canonicalize_name, parsed.projects))
 
     return projects
 

--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -165,7 +165,7 @@ def check(projects):
     log = logging.getLogger('ciu')
     log.info('{0} top-level projects to check'.format(len(projects)))
     print('Finding and checking dependencies ...')
-    blockers = dependencies.blocking_dependencies(projects, pypi.all_py3_projects())
+    blockers = dependencies.blockers(projects)
 
     print('')
     for line in message(blockers):

--- a/caniusepython3/dependencies.py
+++ b/caniusepython3/dependencies.py
@@ -54,44 +54,23 @@ def reasons_to_paths(reasons):
 def dependencies(project_name):
     """Get the dependencies for a project."""
     log = logging.getLogger('ciu')
-    deps = []
-    log.info('Locating {0}'.format(project_name))
+    log.info('Locating dependencies for {}'.format(project_name))
     located = distlib.locators.locate(project_name, prereleases=True)
     if not located:
         log.warning('{0} not found'.format(project_name))
         return None
-    for dep in map(packaging.utils.canonicalize_name, located.run_requires):
-        # Drop any version details from the dependency name.
-        deps.append(pypi.just_name(dep))
-    return deps
+    return {packaging.utils.canonicalize_name(pypi.just_name(dep))
+            for dep in located.run_requires}
 
 
-def blocking_dependencies(projects, py3_projects):
-    """Starting from 'projects', find all projects which are blocking Python 3 usage.
-
-    Any project in 'py3_projects' is considered ported and thus will not have
-    its dependencies searched. Version requirements are also ignored as it is
-    assumed that if a project is updating to support Python 3 then they will be
-    willing to update to the latest version of their dependencies. The only
-    dependencies checked are those required to run the project.
-
-    """
+def blockers(project_names):
     log = logging.getLogger('ciu')
     check = []
-    evaluated = set()
-    for project in map(packaging.utils.canonicalize_name, projects):
+    evaluated = set(pypi.manual_overrides())
+    for project in project_names:
         log.info('Checking top-level project: {0} ...'.format(project))
-        try:
-            dist = distlib.locators.locate(project)
-        except AttributeError:
-            # This is a work around. //bitbucket.org/pypa/distlib/issue/59/ .
-            log.warning('{0} found but had to be skipped.'.format(project))
-            continue
-        if not dist:
-            log.warning('{0} not found'.format(project))
-            continue
-        project = dist.name.lower()  # PyPI can be forgiving about name formats.
-        if project not in py3_projects:
+        evaluated.add(project)
+        if not pypi.supports_py3(project):
             check.append(project)
     reasons = {project: None for project in check}
     thread_pool_executor = concurrent.futures.ThreadPoolExecutor(
@@ -107,16 +86,21 @@ def blocking_dependencies(projects, py3_projects):
                     del reasons[parent]
                     continue
                 log.info('Dependencies of {0}: {1}'.format(project, deps))
+                unchecked_deps = []
                 for dep in deps:
-                    log.info('Checking dependency: {0} ...'.format(dep))
                     if dep in evaluated:
                         log.info('{0} already checked'.format(dep))
-                        continue
                     else:
-                        evaluated.add(dep)
-                    if dep in py3_projects:
-                        continue
-                    reasons[dep] = parent
-                    new_check.append(dep)
+                        unchecked_deps.append(dep)
+                deps_status = zip(unchecked_deps,
+                                  executor.map(pypi.supports_py3,
+                                               unchecked_deps))
+                for dep, ported in deps_status:
+                    if not ported:
+                        reasons[dep] = parent
+                        new_check.append(dep)
+                    # Make sure there's no data race in recording a dependency
+                    # has been evaluated but not reported somewhere.
+                    evaluated.add(dep)
             check = new_check
     return reasons_to_paths(reasons)

--- a/caniusepython3/pypi.py
+++ b/caniusepython3/pypi.py
@@ -14,6 +14,9 @@
 
 from __future__ import unicode_literals
 
+import packaging.utils
+import requests
+
 import concurrent.futures
 import contextlib
 import json
@@ -44,95 +47,36 @@ def just_name(supposed_name):
     """Strip off any versioning or restrictions metadata from a project name."""
     return PROJECT_NAME.match(supposed_name).group(0).lower()
 
-@contextlib.contextmanager
-def pypi_client():
-    client = xmlrpc_client.ServerProxy('https://pypi.org/pypi')
-    try:
-        yield client
-    finally:
-        try:
-            client('close')()
-        except (xml.parsers.expat.ExpatError, xmlrpc_client.Fault):  #pragma: no cover
-            # The close hack is not in Python 2.6.
-            pass
 
+def manual_overrides():
+    """Read the overrides file.
 
-def overrides():
-    """Load a set containing projects who are missing the proper Python 3 classifier.
-
-    Project names are always lowercased.
-
+    An attempt is made to read the file as it currently stands on GitHub, and
+    then only if that fails is the included file used.
     """
-    raw_bytes = pkgutil.get_data(__name__, 'overrides.json')
-    return json.loads(raw_bytes.decode('utf-8'))
-
-
-def py3_classifiers():
-    """Fetch the Python 3-related trove classifiers."""
-    url = 'https://pypi.io/pypi?%3Aaction=list_classifiers'
-    response = urllib_request.urlopen(url)
-    try:
-        try:
-            status = response.status
-        except AttributeError:  #pragma: no cover
-            status = response.code
-        if status != 200:  #pragma: no cover
-            msg = 'PyPI responded with status {0} for {1}'.format(status, url)
-            raise ValueError(msg)
-        data = response.read()
-    finally:
-        response.close()
-    classifiers = data.decode('utf-8').splitlines()
-    base_classifier = 'Programming Language :: Python :: 3'
-    return (classifier for classifier in classifiers
-            if classifier.startswith(base_classifier))
-
-
-def projects_matching_classifier(classifier):
-    """Find all projects matching the specified trove classifier."""
     log = logging.getLogger('ciu')
-    with pypi_client() as client:
-        log.info('Fetching project list for {0!r}'.format(classifier))
-        try:
-            return frozenset(result[0].lower()
-                             for result in client.browse([classifier]))
-        except xml.parsers.expat.ExpatError:  #pragma: no cover
-            # Python 2.6 doesn't like empty results.
-            logging.getLogger('ciu').info("PyPI didn't return any results")
-            return []
+    request = requests.get("https://raw.githubusercontent.com/brettcannon/"
+                           "caniusepython3/master/caniusepython3/overrides.json")
+    if request.status_code == 200:
+        log.info("Overrides loaded from GitHub")
+        overrides = request.json()
+    else:
+        log.info("Overrides loaded from included package data")
+        raw_bytes = pkgutil.get_data(__name__, 'overrides.json')
+        overrides = json.loads(raw_bytes.decode('utf-8'))
+    return frozenset(map(packaging.utils.canonicalize_name, overrides.keys()))
 
 
-def all_py3_projects(manual_overrides=None):
-    """Return the set of names of all projects ported to Python 3, lowercased."""
-    log = logging.getLogger('ciu')
-    projects = set()
-    thread_pool_executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=CPU_COUNT)
-    with thread_pool_executor as executor:
-        for result in map(projects_matching_classifier, py3_classifiers()):
-            projects.update(result)
-    if manual_overrides is None:
-        manual_overrides = overrides()
-    stale_overrides = projects.intersection(manual_overrides)
-    log.info('Adding {0} overrides:'.format(len(manual_overrides)))
-    for override in sorted(manual_overrides):
-        msg = override
-        try:
-            msg += ' ({0})'.format(manual_overrides[override])
-        except TypeError:
-            # No reason a set can't be used.
-            pass
-        log.info('    ' + msg)
-    if stale_overrides:  #pragma: no cover
-        log.info('Unnecessary (and thus harmless) overrides: '
-                 '{0}'.format(stale_overrides))
-    projects.update(manual_overrides)
-    return projects
-
-
-def all_projects():
-    """Get the set of all projects on PyPI."""
-    log = logging.getLogger('ciu')
-    with pypi_client() as client:
-        log.info('Fetching all project names from PyPI')
-        return frozenset(name.lower() for name in client.list_packages())
+def supports_py3(project_name):
+    """Check with PyPI if a project supports Python 3."""
+    log = logging.getLogger("ciu")
+    log.info("Checking {} ...".format(project_name))
+    request = requests.get("https://pypi.org/pypi/{}/json".format(project_name))
+    if request.status_code >= 400:
+        log = logging.getLogger("ciu")
+        log.warning("problem fetching {}, assuming ported ({})".format(
+                        project_name, request.status_code))
+        return True
+    response = request.json()
+    return any(c.startswith("Programming Language :: Python :: 3")
+               for c in response["info"]["classifiers"])

--- a/caniusepython3/pypi.py
+++ b/caniusepython3/pypi.py
@@ -18,21 +18,12 @@ import packaging.utils
 import requests
 
 import concurrent.futures
-import contextlib
 import json
 import logging
 import multiprocessing
 import pkgutil
 import re
-try:
-    import urllib.request as urllib_request
-except ImportError:  #pragma: no cover
-    import urllib2 as urllib_request
-import xml.parsers.expat
-try:
-    import xmlrpc.client as xmlrpc_client
-except ImportError:  #pragma: no cover
-    import xmlrpclib as xmlrpc_client
+
 
 
 try:

--- a/caniusepython3/test/test_check.py
+++ b/caniusepython3/test/test_check.py
@@ -71,3 +71,7 @@ class CheckTest(unittest.TestCase):
     @skip_pypi_timeouts
     def test_ignore_missing_projects(self):
         self.assertTrue(ciu.check(projects=['sdfsjdfsdlfk;jasdflkjasdfdfsdf']))
+
+    @skip_pypi_timeouts
+    def test_manual_overrides(self):
+        self.assertTrue(ciu.check(projects=["unittest2"]))

--- a/caniusepython3/test/test_cli.py
+++ b/caniusepython3/test/test_cli.py
@@ -26,7 +26,7 @@ EXAMPLE_REQUIREMENTS = """
 # From
 #  http://www.pip-installer.org/en/latest/reference/pip_install.html#requirement-specifiers
 # but without the quotes for shell protection.
-FooProject >= 1.2
+Foo.Project >= 1.2
 Fizzy [foo, bar]
 PickyThing<1.6,>1.9,!=1.9.6,<2.0a0,==2.4c1
 Hello
@@ -37,7 +37,7 @@ file:../../lib/project
 """
 
 EXAMPLE_EXTRA_REQUIREMENTS = """
-testingstuff
+testing-stuff
 """
 
 EXAMPLE_METADATA = """Metadata-Version: 1.2
@@ -50,7 +50,7 @@ Author-email: tarek@ziade.org
 License: PSF
 Keywords: keyring,password,crypt
 Requires-Dist: foo; sys.platform == 'okook'
-Requires-Dist: bar
+Requires-Dist: bar.baz
 Platform: UNKNOWN
 """
 
@@ -66,10 +66,10 @@ Requires-Dist: baz
 
 class CLITests(unittest.TestCase):
 
-    expected_requirements = frozenset(['FooProject', 'Fizzy', 'PickyThing',
-                                       'Hello'])
-    expected_extra_requirements = frozenset(['testingstuff'])
-    expected_metadata = frozenset(['foo', 'bar'])
+    expected_requirements = frozenset(['foo-project', 'fizzy', 'pickything',
+                                       'hello'])
+    expected_extra_requirements = frozenset(['testing-stuff'])
+    expected_metadata = frozenset(['foo', 'bar-baz'])
     expected_extra_metadata = frozenset(['baz'])
 
     def setUp(self):
@@ -125,9 +125,9 @@ class CLITests(unittest.TestCase):
         self.assertEqual(set(got), self.expected_metadata)
 
     def test_cli_for_projects(self):
-        args = ['--projects', 'foo', 'bar']
+        args = ['--projects', 'foo', 'bar.baz']
         got = ciu_main.projects_from_cli(args)
-        self.assertEqual(set(got), frozenset(['foo', 'bar']))
+        self.assertEqual(set(got), frozenset(['foo', 'bar-baz']))
 
     def test_message_plural(self):
         blockers = [['A'], ['B']]

--- a/caniusepython3/test/test_dependencies.py
+++ b/caniusepython3/test/test_dependencies.py
@@ -83,6 +83,9 @@ class NetworkTests(unittest.TestCase):
         got = dependencies.blockers(['asdfsadfdsfsdffdfadf'])
         self.assertEqual(got, frozenset())
 
+    def test_manual_overrides(self):
+        self.assertEqual(dependencies.blockers(["unittest2"]), frozenset())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/caniusepython3/test/test_dependencies.py
+++ b/caniusepython3/test/test_dependencies.py
@@ -62,31 +62,12 @@ class DependenciesTests(unittest.TestCase):
         got = dependencies.dependencies('does not matter')
         self.assertEqual({'easy-thumbnail', 'stuff'}, frozenset(got))
 
-
-class BlockingDependenciesTests(unittest.TestCase):
-
-    @mock.patch('caniusepython3.dependencies.dependencies')
-    def test_recursion(self, dependencies_mock):
-        deps = {'a': ['b'], 'b': ['a']}
-        dependencies_mock.side_effect = lambda name: deps[name]
-        got = dependencies.blocking_dependencies(['a'], {})
-        self.assertEqual(frozenset(), got)
-
-    def test_blocking_dependencies_locators_fails(self):
-        # Testing the work around for //bitbucket.org/pypa/distlib/issue/59/ .
-        with mock.patch.object(distlib.locators, 'locate') as locate_mock:
-            py3 = {'py3_project': ''}
-            breaking_project = 'test_project'
-            locate_mock.side_effect = AttributeError()
-            got = dependencies.blocking_dependencies([breaking_project], py3)
-            # If you'd like to test that a message is logged we can use
-            # testfixtures.LogCapture or stdout redirects.
-
+# XXX Tests covering dependency loops, e.g. a -> b, b -> a.
 
 class NetworkTests(unittest.TestCase):
 
-    def test_blocking_dependencies(self):
-        got = dependencies.blocking_dependencies(['mozinfo'], {})
+    def test_blockers(self):
+        got = dependencies.blockers(['mozinfo'])
         want = frozenset([('mozfile', 'mozinfo')])
         self.assertEqual(frozenset(got), want)
 
@@ -98,15 +79,10 @@ class NetworkTests(unittest.TestCase):
         got = dependencies.dependencies('sdflksjdfsadfsadfad')
         self.assertIsNone(got)
 
-    def test_blocking_dependencies_no_project(self):
-        got = dependencies.blocking_dependencies(['asdfsadfdsfsdffdfadf'], {})
+    def test_blockers_no_project(self):
+        got = dependencies.blockers(['asdfsadfdsfsdffdfadf'])
         self.assertEqual(got, frozenset())
 
-    def test_top_level_project_normalization(self):
-        py3 = {'wsgi_intercept': ''}
-        abnormal_name = 'WSGI-intercept'  # Note dash instead of underscore.
-        got = dependencies.blocking_dependencies([abnormal_name], py3)
-        self.assertEqual(got, frozenset())
 
 if __name__ == '__main__':
     unittest.main()

--- a/caniusepython3/test/test_pypi.py
+++ b/caniusepython3/test/test_pypi.py
@@ -56,6 +56,7 @@ class OverridesTests(unittest.TestCase):
     def test_success(self):
         overrides = pypi.manual_overrides()
         self.assertTrue(len(overrides) > 10)
+        self.assertIn("unittest2", overrides)
 
 
 class NetworkTests(unittest.TestCase):

--- a/caniusepython3/test/test_pypi.py
+++ b/caniusepython3/test/test_pypi.py
@@ -17,6 +17,8 @@ from __future__ import unicode_literals
 from caniusepython3 import pypi
 from caniusepython3.test import unittest, skip_pypi_timeouts
 
+import packaging.utils
+
 
 class NameTests(unittest.TestCase):
 
@@ -45,37 +47,17 @@ class NameTests(unittest.TestCase):
 
 class OverridesTests(unittest.TestCase):
 
-    def test_all_lowercase(self):
-        for name in pypi.overrides():
-            self.assertEqual(name, name.lower())
+    @skip_pypi_timeouts
+    def test_canonicalization(self):
+        for name in pypi.manual_overrides():
+            self.assertEqual(name, packaging.utils.canonicalize_name(name))
 
 
 class NetworkTests(unittest.TestCase):
 
-    def py3_classifiers(self):
-        key_classifier = 'Programming Language :: Python :: 3'
-        classifiers = frozenset(pypi.py3_classifiers())
-        self.asssertIn(key_classifier, classifiers)
-        self.assertGreaterEqual(len(classifiers), 5)
-        for classifier in classifiers:
-            self.assertTrue(classifier.startswith(key_classifier))
-
-
     @skip_pypi_timeouts
-    def test_all_py3_projects(self):
-        projects = pypi.all_py3_projects()
-        self.assertGreater(len(projects), 3000)
-        self.assertTrue(all(project == project.lower() for project in projects))
-        self.assertTrue(frozenset(pypi.overrides().keys()).issubset(projects))
-
-    @skip_pypi_timeouts
-    def test_all_py3_projects_explicit_overrides(self):
-        added_port = 'asdfasdfasdfadsffffdasfdfdfdf'
-        projects = pypi.all_py3_projects(set([added_port]))
-        self.assertIn(added_port, projects)
-
-    @skip_pypi_timeouts
-    def test_all_projects(self):
-        projects = pypi.all_projects()
-        self.assertTrue(all(project == project.lower() for project in projects))
-        self.assertGreaterEqual(len(projects), 40000)
+    def test_supports_py3(self):
+        self.assertTrue(pypi.supports_py3("caniusepython3"))
+        self.assertFalse(pypi.supports_py3("pil"))
+        # Unfound projects are considered ported.
+        self.assertTrue(pypi.supports_py3("sdfffavsafasvvavfdvavfavf"))

--- a/caniusepython3/test/test_pypi.py
+++ b/caniusepython3/test/test_pypi.py
@@ -52,6 +52,11 @@ class OverridesTests(unittest.TestCase):
         for name in pypi.manual_overrides():
             self.assertEqual(name, packaging.utils.canonicalize_name(name))
 
+    @skip_pypi_timeouts
+    def test_success(self):
+        overrides = pypi.manual_overrides()
+        self.assertTrue(len(overrides) > 10)
+
 
 class NetworkTests(unittest.TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('dev_requirements.txt') as file:
     tests_require = [dep.strip() for dep in file.readlines()]
 
 setup(name='caniusepython3',
-      version='3.4.1',
+      version='4.0.0',
       description='Determine what projects are blocking you from porting to Python 3',
       long_description=long_description,
       author='Brett Cannon',
@@ -22,7 +22,7 @@ setup(name='caniusepython3',
       packages=['caniusepython3', 'caniusepython3.test'],
       include_package_data=True,
       install_requires=['distlib', 'setuptools', 'packaging', 'pip',  # Input flexibility
-                        'argparse', 'futures'],  # Functionality
+                        'argparse', 'futures', 'requests'],  # Functionality
       tests_require=tests_require,  # Testing, external due to Travis
       test_suite='caniusepython3.test',
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('dev_requirements.txt') as file:
     tests_require = [dep.strip() for dep in file.readlines()]
 
 setup(name='caniusepython3',
-      version='3.4.0',
+      version='3.4.1',
       description='Determine what projects are blocking you from porting to Python 3',
       long_description=long_description,
       author='Brett Cannon',


### PR DESCRIPTION
Dropping the use of the XML-RPC API for PyPI to increase performance (individual requests hits the Fastly cache instead of relying on PyPI being responsive).

As part of this work, also make the overrides data loaded from GitHub when possible, only falling back on the potentially stale information included in the package as necessary.

Closes #128 and #149 