### PR TITLE
Add gym to override

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -11,6 +11,7 @@
     "functools32": "https://pypi.python.org/pypi/functools32",
     "geoip": "https://pypi.python.org/pypi/GeoIP/",
     "grab": "https://pypi.python.org/pypi/grab",
+    "gym": "https://github.com/openai/gym/blob/master/tox.ini",
     "hashids": "https://pypi.python.org/pypi/hashids",
     "ipaddr": "https://docs.python.org/3/library/ipaddress.html",
     "jinja": "http://jinja.pocoo.org/docs/switching/#jinja1",


### PR DESCRIPTION
The project page says:
> We currently support Linux and OS X running Python 2.7 or 3.5.