### PR TITLE
Override sklearn with scikit-learn

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -30,6 +30,7 @@
     "python-oauth2": "https://github.com/wndhydrnt/python-oauth2/blob/master/setup.py",
     "python-openid": "https://pypi.python.org/pypi/python3-openid",
     "ssh": "https://github.com/bitprophet/ssh/",
+    "sklearn": "https://pypi.python.org/pypi/scikit-learn",
     "ssl": "http://docs.python.org/3/library/ssl.html",
     "suds": "https://pypi.python.org/pypi/suds-jurko",
     "trisdb-py": "https://github.com/tiepologian/trisdb-py/blob/master/setup.cfg",

--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -30,7 +30,7 @@
     "python-oauth2": "https://github.com/wndhydrnt/python-oauth2/blob/master/setup.py",
     "python-openid": "https://pypi.python.org/pypi/python3-openid",
     "ssh": "https://github.com/bitprophet/ssh/",
-    "sklearn": "https://pypi.python.org/pypi/scikit-learn",
+    "sklearn": "https://pypi.org/project/scikit-learn",
     "ssl": "http://docs.python.org/3/library/ssl.html",
     "suds": "https://pypi.python.org/pypi/suds-jurko",
     "trisdb-py": "https://github.com/tiepologian/trisdb-py/blob/master/setup.cfg",


### PR DESCRIPTION
https://pypi.org/project/sklearn/ says "Use scikit-learn instead" as it's just a wrapper (https://github.com/scikit-learn/scikit-learn/issues/8215).

```console
$ caniusepython3 --projects sklearn
Finding and checking dependencies ...

You need 1 project to transition to Python 3.
Of that 1 project, 1 has no direct dependencies blocking its transition:

  sklearn
```
```console
$ caniusepython3 --projects scikit-learn
Finding and checking dependencies ...

🎉  You have 0 projects blocking you from using Python 3!
```