### PR TITLE
Overrides: subprocess32 is part of Python's standard library

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -31,6 +31,7 @@
     "python-openid": "https://pypi.python.org/pypi/python3-openid",
     "ssh": "https://github.com/bitprophet/ssh/",
     "ssl": "http://docs.python.org/3/library/ssl.html",
+    "subprocess32": "https://pypi.org/project/subprocess32/",
     "suds": "https://pypi.python.org/pypi/suds-jurko",
     "trisdb-py": "https://github.com/tiepologian/trisdb-py/blob/master/setup.cfg",
     "unittest2": "http://docs.python.org/3/library/unittest.html",


### PR DESCRIPTION
> This is a backport of the subprocess standard library module from Python 3.2 - 3.5 for use on Python 2.

https://pypi.org/project/subprocess32/