### PR TITLE
futures is a backport from Python 3's standard library

### DIFF
--- a/caniusepython3/overrides.json
+++ b/caniusepython3/overrides.json
@@ -9,6 +9,7 @@
     "flask-security": "http://pythonhosted.org/Flask-Security/changelog.html#version-1-7-3",
     "flask-principal": "http://pythonhosted.org/Flask-Principal/changelog.html",
     "functools32": "https://pypi.python.org/pypi/functools32",
+    "futures": "https://docs.python.org/3/library/concurrent.futures.html",
     "geoip": "https://pypi.python.org/pypi/GeoIP/",
     "grab": "https://pypi.python.org/pypi/grab",
     "gym": "https://github.com/openai/gym/blob/master/tox.ini",


### PR DESCRIPTION
> This is a backport of the concurrent.futures standard library module to Python 2.

https://pypi.org/project/futures/