### PR TITLE
Check wheel versions and Python 3 only

### DIFF
--- a/caniusepython3/dependencies.py
+++ b/caniusepython3/dependencies.py
@@ -69,7 +69,7 @@ def blockers(project_names):
 
     def supports_py3(project_name):
         if project_name in overrides:
-            return True
+            return pypi.CanIUsePython3.python3_supported
         else:
             return pypi.supports_py3(project_name)
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='caniusepython3',
       install_requires=['distlib', 'setuptools', 'packaging',  # Input flexibility
                         'argparse', 'backports.functools_lru_cache',
                         'futures ; python_version=="2.7"',
+                        'enum34 ; python_version=="2.7"',
                         'requests'],  # Functionality
       tests_require=tests_require,  # Testing, external due to Travis
       test_suite='caniusepython3.test',


### PR DESCRIPTION
The PyPI project checker falls back to wheel filenames. supports_py3()
also supports if a project is Python 3 only.

Signed-off-by: Christian Heimes <christian@python.org>