### PR TITLE
Add exclude parameters to be passed in.

### DIFF
--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -45,6 +45,8 @@ def projects_from_cli(args):
                         help='name(s) of projects to test for Python 3 support')
     parser.add_argument('--verbose', '-v', action='store_true',
                         help='verbose output (e.g. list compatibility overrides)')
+    parser.add_argument('--exclude', '-e', action='append', default=[],
+                        help='Ignore list')
     parsed = parser.parse_args(args)
 
     if not (parsed.requirements or parsed.metadata or parsed.projects):
@@ -61,6 +63,7 @@ def projects_from_cli(args):
     projects.extend(projects_.projects_from_metadata(metadata))
     projects.extend(map(packaging.utils.canonicalize_name, parsed.projects))
 
+    projects = [i for i in projects if i not in parsed.exclude]
     return projects
 
 


### PR DESCRIPTION
- [x] Can pass libraries you want to exclude. ```python caniusepython3/__main__.py --exclude django-health-check drf-ujson poster foursquare -r requirements.txt``` Fixes https://github.com/brettcannon/caniusepython3/issues/198
