### PR TITLE
Add exclude parameters to be passed in.

### DIFF
--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -45,6 +45,8 @@ def projects_from_cli(args):
                         help='name(s) of projects to test for Python 3 support')
     parser.add_argument('--verbose', '-v', action='store_true',
                         help='verbose output (e.g. list compatibility overrides)')
+    parser.add_argument('--exclude', '-e', action='append', default=[],
+                        help='Ignore list')
     parsed = parser.parse_args(args)
 
     if not (parsed.requirements or parsed.metadata or parsed.projects):
@@ -61,6 +63,7 @@ def projects_from_cli(args):
     projects.extend(projects_.projects_from_metadata(metadata))
     projects.extend(map(packaging.utils.canonicalize_name, parsed.projects))
 
+    projects = [i for i in projects if i not in parsed.exclude]
     return projects
 
 

--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals
 from caniusepython3 import dependencies
 from caniusepython3 import projects as projects_
 
-import distlib.metadata
 import packaging.utils
 
 import argparse
@@ -63,7 +62,7 @@ def projects_from_cli(args):
     projects.extend(projects_.projects_from_metadata(metadata))
     projects.extend(map(packaging.utils.canonicalize_name, parsed.projects))
 
-    projects = [i for i in projects if i not in parsed.exclude]
+    projects = {i for i in projects if i not in parsed.exclude}
     return projects
 
 

--- a/caniusepython3/test/test_cli.py
+++ b/caniusepython3/test/test_cli.py
@@ -66,6 +66,7 @@ License: Apache
 Requires-Dist: baz
 """
 
+
 class CLITests(unittest.TestCase):
 
     expected_requirements = frozenset(['foo-project', 'fizzy', 'pickything',
@@ -117,6 +118,17 @@ class CLITests(unittest.TestCase):
             args = ['--requirements', file.name]
             got = ciu_main.projects_from_cli(args)
         self.assertEqual(set(got), self.expected_requirements)
+
+    def test_excluding_requirements(self):
+        with tempfile.NamedTemporaryFile('w') as file:
+            file.write(EXAMPLE_REQUIREMENTS)
+            file.flush()
+            args = ['--requirements', file.name, '--exclude', 'pickything']
+            got = ciu_main.projects_from_cli(args)
+        expected_requirements = set(self.expected_requirements)
+        expected_requirements.remove('pickything')
+        self.assertNotIn('pickything', set(got))
+        self.assertEqual(set(got), expected_requirements)
 
     def test_cli_for_metadata(self):
         with tempfile.NamedTemporaryFile('w') as file:


### PR DESCRIPTION
- [x] Can pass libraries you want to exclude. ```python caniusepython3/__main__.py --exclude django-health-check drf-ujson poster foursquare -r requirements.txt``` Fixes https://github.com/brettcannon/caniusepython3/issues/198
