### PR TITLE
Travis CI: Remove deprecated sudo tag, Py3.4 Add Py3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
     include:
       - python: "3.7"
         dist: xenial    # required for >= Python 3.7
+      - python: "3.7-dev"
+        dist: xenial    # required for >= Python 3.7
       - python: "3.8-dev"
         dist: xenial    # required for >= Python 3.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,19 @@
 language: python
 
-sudo: false
 cache: pip
 
 python:
     - "2.7"
     - "pypy"
-    - "3.4"
     - "3.5"
-    - "3.6-dev"
+    - "3.6"
 
 matrix:
     include:
-      - python: "3.7-dev"
-        dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-        sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      - python: "3.7"
+        dist: xenial    # required for >= Python 3.7
       - python: "3.8-dev"
-        dist: xenial    # required for Python 3.8-dev (travis-ci/travis-ci#9069)
-        sudo: required  # required for Python 3.8-dev (travis-ci/travis-ci#9069)
+        dist: xenial    # required for >= Python 3.7
 
 install:
   - pip install tox-travis

--- a/caniusepython3/test/test_check.py
+++ b/caniusepython3/test/test_check.py
@@ -19,7 +19,7 @@ from caniusepython3.test import unittest, skip_pypi_timeouts
 
 import tempfile
 
-py2_project = 'supervisor'
+py2_project = 'pulp'  # https://pypi.org/project/PuLP/
 
 EXAMPLE_METADATA = """Metadata-Version: 1.2
 Name: TestingMetadata


### PR DESCRIPTION
1. Travis has deprecated the __sudo__ tag.
2. Drop Python 3.4 because it is EOL.
3. Add Python 3.7 release instead of dev.
4. Modified the test because [__Supervisor__](https://github.com/Supervisor/supervisor) is now compatible with Python 3. 👍 