### PR TITLE
Support version

### DIFF
--- a/caniusepython3/__init__.py
+++ b/caniusepython3/__init__.py
@@ -46,7 +46,7 @@ def check(requirements_paths=[], metadata=[], projects=[]):
     manual_overrides = pypi.manual_overrides()
 
     for dependency in dependencies:
-        if dependency in manual_overrides:
+        if dependency['name'] in manual_overrides:
             continue
         elif not pypi.supports_py3(dependency):
             return False

--- a/caniusepython3/__main__.py
+++ b/caniusepython3/__main__.py
@@ -41,7 +41,10 @@ def projects_from_cli(args):
         with io.open(metadata_path) as file:
             metadata.append(file.read())
     projects.extend(projects_.projects_from_metadata(metadata))
-    projects.extend(map(packaging.utils.canonicalize_name, args.projects))
+
+    # transform list of projects into requirements:
+    projects.extend(projects_.projects_from_list(args.projects))
+
 
     projects = [i for i in projects if i['name'] not in args.exclude]
     return projects

--- a/caniusepython3/command.py
+++ b/caniusepython3/command.py
@@ -35,10 +35,10 @@ class Command(setuptools.Command):
             for project in requirements:
                 if not project:
                     continue
-                projects.append(pypi.just_name(project))
+                projects.append({'name': pypi.just_name(project)})
         extras = getattr(self.distribution, 'extras_require', None) or {}
         for value in extras.values():
-            projects.extend(map(pypi.just_name, value))
+            projects.append({'name': pypi.just_name(value)})
         return projects
 
     def initialize_options(self):

--- a/caniusepython3/dependencies.py
+++ b/caniusepython3/dependencies.py
@@ -14,7 +14,7 @@
 
 from __future__ import unicode_literals
 
-import distlib.locators
+from distlib.locators import locate
 import packaging.utils
 
 import caniusepython3 as ciu
@@ -51,43 +51,50 @@ def reasons_to_paths(reasons):
     return paths
 
 
-def dependencies(project_name):
+def dependencies(project):
     """Get the dependencies for a project."""
     log = logging.getLogger('ciu')
-    log.info('Locating dependencies for {}'.format(project_name))
-    located = distlib.locators.locate(project_name, prereleases=True)
+    log.info('Locating dependencies for {}'.format(project['name']))
+    located = locate(project['name'], prereleases=True)
     if not located:
-        log.warning('{0} not found'.format(project_name))
+        log.warning('{0} not found'.format(project['name']))
         return None
-    return {packaging.utils.canonicalize_name(pypi.just_name(dep))
-            for dep in located.run_requires}
+    deps = []
+    for dep in located.run_requires:
+        d = locate(dep)
+        deps.append({
+            'name': packaging.utils.canonicalize_name(d.name),
+            'version': packaging.utils.canonicalize_version(d.version)
+        })
+
+    return deps
 
 
-def blockers(project_names):
+def blockers(projects, keep_version=False):
     log = logging.getLogger('ciu')
     overrides = pypi.manual_overrides()
 
-    def supports_py3(project_name):
-        if project_name in overrides:
+    def supports_py3(project):
+        if project['name'] in overrides:
             return True
         else:
-            return pypi.supports_py3(project_name)
+            return pypi.supports_py3(project, keep_version)
 
     check = []
     evaluated = set(overrides)
-    for project in project_names:
+    for project in projects:
         log.info('Checking top-level project: {0} ...'.format(project))
-        evaluated.add(project)
+        evaluated.add(project['name'])
         if not supports_py3(project):
             check.append(project)
-    reasons = {project: None for project in check}
+    reasons = {project['name']: None for project in check}
     thread_pool_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=ciu.CPU_COUNT)
     with thread_pool_executor as executor:
         while len(check) > 0:
             new_check = []
             for parent, deps in zip(check, executor.map(dependencies, check)):
-                if deps is None:
+                if not deps:
                     # Can't find any results for a project, so ignore it so as
                     # to not accidentally consider indefinitely that a project
                     # can't port.
@@ -96,7 +103,7 @@ def blockers(project_names):
                 log.info('Dependencies of {0}: {1}'.format(project, deps))
                 unchecked_deps = []
                 for dep in deps:
-                    if dep in evaluated:
+                    if dep['name'] in evaluated:
                         log.info('{0} already checked'.format(dep))
                     else:
                         unchecked_deps.append(dep)
@@ -105,10 +112,10 @@ def blockers(project_names):
                                                unchecked_deps))
                 for dep, ported in deps_status:
                     if not ported:
-                        reasons[dep] = parent
+                        reasons[dep['name']] = parent
                         new_check.append(dep)
                     # Make sure there's no data race in recording a dependency
                     # has been evaluated but not reported somewhere.
-                    evaluated.add(dep)
+                    evaluated.add(dep['name'])
             check = new_check
     return reasons_to_paths(reasons)

--- a/caniusepython3/dependencies.py
+++ b/caniusepython3/dependencies.py
@@ -98,7 +98,7 @@ def blockers(projects, keep_version=False):
                     # Can't find any results for a project, so ignore it so as
                     # to not accidentally consider indefinitely that a project
                     # can't port.
-                    del reasons[parent]
+                    del reasons[parent['name']]
                     continue
                 log.info('Dependencies of {0}: {1}'.format(project, deps))
                 unchecked_deps = []

--- a/caniusepython3/projects.py
+++ b/caniusepython3/projects.py
@@ -12,10 +12,43 @@ import io
 import logging
 import re
 
+log = logging.getLogger('ciu')
+
+def _requirement_to_dict(req):
+    if not req.name:
+        log.warning('A requirement lacks a name '
+                    '(e.g. no `#egg` on a `file:` path)')
+    elif req.url:
+        log.warning(
+            'Skipping {0}: URL-specified projects unsupported'.format(req.name))
+    else:
+        project = {
+            'name': packaging.utils.canonicalize_name(req.name)
+        }
+        if len(req.specifier) > 0:
+            project['version'] = packaging.utils.canonicalize_version(
+                [s.version for s in req.specifier][0]
+            )
+        return project
+
+
+def projects_from_list(projects_list):
+    """Convert the list of projects to projects dict"""
+    projects = []
+    for p in projects_list:
+        try:
+            r = packaging.requirements.Requirement(p)
+            pd = _requirement_to_dict(r)
+            if pd:
+                projects.append(pd)
+
+        except packaging.requirements.InvalidRequirement:
+            log.warning('Skipping {0!r}: could not parse requirement'.format(line))
+
+    return projects
 
 def projects_from_requirements(requirements):
     """Extract the project dependencies from a Requirements specification."""
-    log = logging.getLogger('ciu')
     valid_reqs = []
     for requirements_path in requirements:
         with io.open(requirements_path) as file:
@@ -34,22 +67,9 @@ def projects_from_requirements(requirements):
                 log.warning('Skipping {0!r}: could not parse requirement'.format(line))
         projects = []
         for req in reqs:
-            if not req.name:
-                log.warning('A requirement lacks a name '
-                            '(e.g. no `#egg` on a `file:` path)')
-            elif req.url:
-                log.warning(
-                    'Skipping {0}: URL-specified projects unsupported'.format(req.name))
-            else:
-                project = {
-                    'name': packaging.utils.canonicalize_name(req.name)
-                }
-                if len(req.specifier) > 0:
-                    project['version'] = packaging.utils.canonicalize_version(
-                        [s.version for s in req.specifier][0]
-                    )
-
-                valid_reqs.append(project)
+            pd = _requirement_to_dict(req)
+            if pd:
+                valid_reqs.append(pd)
 
     return valid_reqs
 

--- a/caniusepython3/projects.py
+++ b/caniusepython3/projects.py
@@ -31,6 +31,7 @@ def projects_from_requirements(requirements):
                 reqs.append(packaging.requirements.Requirement(line))
             except packaging.requirements.InvalidRequirement:
                 log.warning('Skipping {0!r}: could not parse requirement'.format(line))
+        projects = []
         for req in reqs:
             if not req.name:
                 log.warning('A requirement lacks a name '
@@ -39,8 +40,17 @@ def projects_from_requirements(requirements):
                 log.warning(
                     'Skipping {0}: URL-specified projects unsupported'.format(req.name))
             else:
-                valid_reqs.append(req.name)
-    return frozenset(map(packaging.utils.canonicalize_name, valid_reqs))
+                project = {
+                    'name': packaging.utils.canonicalize_name(req.name)
+                }
+                if len(req.specifier) > 0:
+                    project['version'] = packaging.utils.canonicalize_version(
+                        [s.version for s in req.specifier][0]
+                    )
+
+                valid_reqs.append(project)
+
+    return valid_reqs
 
 
 def projects_from_metadata(metadata):

--- a/caniusepython3/projects.py
+++ b/caniusepython3/projects.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from caniusepython3 import pypi
 
 import distlib.metadata
+from distlib.locators import locate
 import packaging.requirements
 import packaging.utils
 
@@ -58,5 +59,15 @@ def projects_from_metadata(metadata):
     projects = []
     for data in metadata:
         meta = distlib.metadata.Metadata(fileobj=io.StringIO(data))
-        projects.extend(pypi.just_name(project) for project in meta.run_requires)
-    return frozenset(map(packaging.utils.canonicalize_name, projects))
+        projects.append(
+            {
+                'name': packaging.utils.canonicalize_name(meta.name), 
+                'version': packaging.utils.canonicalize_version(meta.version)
+            })
+        for dep in meta.run_requires:
+            d = locate(dep)
+            projects.append({
+                'name': packaging.utils.canonicalize_name(d.name),
+                'version': packaging.utils.canonicalize_version(d.version)
+            })
+    return projects

--- a/caniusepython3/pypi.py
+++ b/caniusepython3/pypi.py
@@ -75,15 +75,19 @@ def _manual_overrides(_cache_date=None):
     return frozenset(map(packaging.utils.canonicalize_name, overrides.keys()))
 
 
-def supports_py3(project_name):
+def supports_py3(project, keep_version=False):
     """Check with PyPI if a project supports Python 3."""
     log = logging.getLogger("ciu")
-    log.info("Checking {} ...".format(project_name))
-    request = requests.get("https://pypi.org/pypi/{}/json".format(project_name))
+    log.info("Checking {} ...".format(project))
+    if project.get('version') and keep_version:
+        request = requests.get("https://pypi.org/pypi/{}/{}/json".format(
+            project['name'], project['version']))
+    else:
+        request = requests.get("https://pypi.org/pypi/{}/json".format(project['name']))
     if request.status_code >= 400:
         log = logging.getLogger("ciu")
         log.warning("problem fetching {}, assuming ported ({})".format(
-                        project_name, request.status_code))
+                        project, request.status_code))
         return True
     response = request.json()
     return any(c.startswith("Programming Language :: Python :: 3")

--- a/caniusepython3/test/test_check.py
+++ b/caniusepython3/test/test_check.py
@@ -40,11 +40,16 @@ class CheckTest(unittest.TestCase):
 
     @skip_pypi_timeouts
     def test_success(self):
-        self.assertTrue(ciu.check(projects=['scipy', 'numpy', 'ipython']))
+        projects = [
+            {'name': 'scipy'},
+            {'name': 'numpy'},
+            {'name': 'ipython'}
+        ]
+        self.assertTrue(ciu.check(projects=projects))
 
     @skip_pypi_timeouts
     def test_failure(self):
-        self.assertFalse(ciu.check(projects=[py2_project]))
+        self.assertFalse(ciu.check(projects=[{'name': py2_project}]))
 
     @skip_pypi_timeouts
     def test_requirements(self):
@@ -66,12 +71,12 @@ class CheckTest(unittest.TestCase):
     def test_case_insensitivity(self):
         funky_name = (py2_project[:len(py2_project)].lower() +
                       py2_project[len(py2_project):].upper())
-        self.assertFalse(ciu.check(projects=[funky_name]))
+        self.assertFalse(ciu.check(projects=[{'name': funky_name}]))
 
     @skip_pypi_timeouts
     def test_ignore_missing_projects(self):
-        self.assertTrue(ciu.check(projects=['sdfsjdfsdlfk;jasdflkjasdfdfsdf']))
+        self.assertTrue(ciu.check(projects=[{'name':'sdfsjdfsdlfk;jasdflkjasdfdfsdf'}]))
 
     @skip_pypi_timeouts
     def test_manual_overrides(self):
-        self.assertTrue(ciu.check(projects=["unittest2"]))
+        self.assertTrue(ciu.check(projects=[{'name': "unittest2"}]))

--- a/caniusepython3/test/test_dependencies.py
+++ b/caniusepython3/test/test_dependencies.py
@@ -59,7 +59,7 @@ class DependenciesTests(unittest.TestCase):
                 self.run_requires = run_requires
         fake_deps = FakeLocated(['easy_thumbnail', 'stuff>=4.0.0'])
         locate_mock.side_effect = lambda *args, **kargs: fake_deps
-        got = dependencies.dependencies('does not matter')
+        got = dependencies.dependencies({'name':'does not matter'})
         self.assertEqual({'easy-thumbnail', 'stuff'}, frozenset(got))
 
 # XXX Tests covering dependency loops, e.g. a -> b, b -> a.
@@ -67,24 +67,24 @@ class DependenciesTests(unittest.TestCase):
 class NetworkTests(unittest.TestCase):
 
     def test_blockers(self):
-        got = frozenset(dependencies.blockers(['ralph_scrooge']))
+        got = frozenset(dependencies.blockers([{'name':'ralph_scrooge'}]))
         want = frozenset([('ralph', 'ralph_scrooge'), ('ralph-assets', 'ralph_scrooge')])
         self.assertEqual(got, want)
 
     def test_dependencies(self):
-        got = dependencies.dependencies('pastescript')
+        got = dependencies.dependencies({'name': 'pastescript'})
         self.assertEqual(set(got), frozenset(['six', 'pastedeploy', 'paste']))
 
     def test_dependencies_no_project(self):
-        got = dependencies.dependencies('sdflksjdfsadfsadfad')
+        got = dependencies.dependencies({'name': 'sdflksjdfsadfsadfad'})
         self.assertIsNone(got)
 
     def test_blockers_no_project(self):
-        got = dependencies.blockers(['asdfsadfdsfsdffdfadf'])
+        got = dependencies.blockers([{'name':'asdfsadfdsfsdffdfadf'}])
         self.assertEqual(got, frozenset())
 
     def test_manual_overrides(self):
-        self.assertEqual(dependencies.blockers(["unittest2"]), frozenset())
+        self.assertEqual(dependencies.blockers([{'name':"unittest2"}]), frozenset())
 
 
 if __name__ == '__main__':

--- a/caniusepython3/test/test_pypi.py
+++ b/caniusepython3/test/test_pypi.py
@@ -63,7 +63,7 @@ class NetworkTests(unittest.TestCase):
 
     @skip_pypi_timeouts
     def test_supports_py3(self):
-        self.assertTrue(pypi.supports_py3("caniusepython3"))
-        self.assertFalse(pypi.supports_py3("pil"))
+        self.assertTrue(pypi.supports_py3({'name':"caniusepython3"}))
+        self.assertFalse(pypi.supports_py3({'name':"pil"}))
         # Unfound projects are considered ported.
-        self.assertTrue(pypi.supports_py3("sdfffavsafasvvavfdvavfavf"))
+        self.assertTrue(pypi.supports_py3({'name':"sdfffavsafasvvavfdvavfavf"}))


### PR DESCRIPTION
Hi, 
`caniusepython3` project checks if the latest version of the dependency supports python3. this can be problematic for two reasons:
### It's misleading:
`ciup3` will tell me that a package X is compatible with python3 but since I have an older version installed I will not try to investigate and  after switching to python3 my project will broke.

### It's all about minimizing upgrade costs:
Since upgrading costs too much, we use tools to minimize this cost, as of security vulnerabilities, we use vulnerability assessment tools to decide weather we are impacted or not. to avoid upgrading.


### What's done:
- [x] refactor datastructure
- [x] requirements
- [x] metadata
- [x] projects
- [x]  Option in the CLI to choose to test the current installed version.
- [x]  Check PyPi with the specified version.
