### PR TITLE
Bugfixes

### DIFF
--- a/caniusepython3/command.py
+++ b/caniusepython3/command.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals
 import setuptools
 import sys
 
-import caniusepython3 as ciu
 import caniusepython3.__main__ as ciu_main
 from caniusepython3 import pypi
 

--- a/caniusepython3/dependencies.py
+++ b/caniusepython3/dependencies.py
@@ -93,7 +93,7 @@ def blockers(project_names, index_url=pypi.PYPI_INDEX_URL):
                     # can't port.
                     del reasons[parent]
                     continue
-                log.info('Dependencies of {0}: {1}'.format(project, deps))
+                log.info('Dependencies of {0}: {1}'.format(parent, deps))
                 unchecked_deps = []
                 for dep in deps:
                     if dep in evaluated:

--- a/caniusepython3/test/test_pylint_checker.py
+++ b/caniusepython3/test/test_pylint_checker.py
@@ -21,7 +21,7 @@ try:
     import sys
     import tokenize
 
-    from astroid import test_utils
+    from astroid import builder
     from pylint import testutils
     from pylint.testutils import CheckerTestCase
 
@@ -58,7 +58,7 @@ class StrictPython3CheckerTest(CheckerTestCase):
     CHECKER_CLASS = StrictPython3Checker
 
     def check_not_builtin(self, builtin_name, message):
-        node = test_utils.extract_node(builtin_name + '  #@')
+        node = builder.extract_node(builtin_name + '  #@')
         with self.assertAddsMessages(testutils.Message(message, node=node)):
             self.checker.visit_name(node)
 
@@ -67,7 +67,7 @@ class StrictPython3CheckerTest(CheckerTestCase):
         self.check_not_builtin('open', 'open-builtin')
 
     def test_dict_comprehension(self):
-        node = test_utils.extract_node('{e:"1" for e in ["one", "two"]} #@')
+        node = builder.extract_node('{e:"1" for e in ["one", "two"]} #@')
         with self.assertNoMessages():
             self.checker.visit_name(node)
 


### PR DESCRIPTION
`dependencies.py` is logging whatever the last project of the previous for-loop was instead of the parent node.